### PR TITLE
render information with different namespace

### DIFF
--- a/src/libsbgn-render.js
+++ b/src/libsbgn-render.js
@@ -79,20 +79,21 @@ ColorDefinition.fromXML = function (string) {
  * @return {ColorDefinition}
  */
 ColorDefinition.fromObj = function (jsObj) {
-	if (typeof jsObj.colorDefinition == 'undefined') {
+	var colorDefinitionNode = utils.getChildByNameIgnoringNamespace(jsObj, "colorDefinition");
+	if (colorDefinitionNode === null) {
 		throw new Error("Bad XML provided, expected tagName colorDefinition, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var colorDefinition = new ns.ColorDefinition();
-	jsObj = jsObj.colorDefinition;
-	if(typeof jsObj != 'object') { // nothing inside, empty xml
+	jsObj = colorDefinitionNode;
+	if (typeof jsObj != 'object') { // nothing inside, empty xml
 		return colorDefinition;
 	}
 
-	if(jsObj.$) { // we have some attributes
+	if (jsObj.$) { // we have some attributes
 		var attributes = jsObj.$;
-		colorDefinition.id = attributes.id || null;
-		colorDefinition.value = attributes.value || null;
+		colorDefinition.id = utils.getChildByNameIgnoringNamespace(attributes, "id");
+		colorDefinition.value = utils.getChildByNameIgnoringNamespace(attributes, "value");
 	}
 	return colorDefinition;
 };
@@ -176,19 +177,21 @@ ListOfColorDefinitions.fromXML = function (string) {
  * @return {ListOfColorDefinitions}
  */
 ListOfColorDefinitions.fromObj = function (jsObj) {
-	if (typeof jsObj.listOfColorDefinitions == 'undefined') {
+	var listOfColorDefinitionsNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfColorDefinitions");
+	if (listOfColorDefinitionsNode === null) {
 		throw new Error("Bad XML provided, expected tagName listOfColorDefinitions, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var listOfColorDefinitions = new ns.ListOfColorDefinitions();
-	jsObj = jsObj.listOfColorDefinitions;
-	if(typeof jsObj != 'object') { // nothing inside, empty xml
+	jsObj = listOfColorDefinitionsNode;
+	if (typeof jsObj != 'object') { // nothing inside, empty xml
 		return listOfColorDefinitions;
 	}
 
 	// children
-	if(jsObj.colorDefinition) {
-		var colorDefinitions = jsObj.colorDefinition;
+	var colorDefinitionNode = utils.getChildByNameIgnoringNamespace(jsObj, "colorDefinition");
+	if(colorDefinitionNode) {
+		var colorDefinitions = colorDefinitionNode;
 		for (var i=0; i < colorDefinitions.length; i++) {
 			var colorDefinition = ns.ColorDefinition.fromObj({colorDefinition: colorDefinitions[i]});
 			listOfColorDefinitions.addColorDefinition(colorDefinition);
@@ -349,37 +352,37 @@ RenderGroup.fromXML = function (string) {
  * @return {RenderGroup}
  */
 RenderGroup.fromObj = function (jsObj) {
-	if (typeof jsObj.g == 'undefined') {
+	var gNode = utils.getChildByNameIgnoringNamespace(jsObj, "g");
+	if (gNode === null) {
 		throw new Error("Bad XML provided, expected tagName g, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var g = new ns.RenderGroup();
-	jsObj = jsObj.g;
-	if(typeof jsObj != 'object') { // nothing inside, empty xml
+	jsObj = gNode;
+	if (typeof jsObj != 'object') { // nothing inside, empty xml
 		return g;
 	}
-
-	if(jsObj.$) { // we have some attributes
+	if (jsObj.$) { // we have some attributes
 		var attributes = jsObj.$;
-		g.id 					 = attributes.id || null;
-		g.fontSize 				 = attributes.fontSize || null;
-		g.fontFamily 			 = attributes.fontFamily || null;
-		g.fontWeight 			 = attributes.fontWeight || null;
-		g.fontStyle 			 = attributes.fontStyle || null;
-		g.fontColor				 = attributes.fontColor || null;
-		g.textAnchor 			 = attributes.textAnchor || null;
-		g.vtextAnchor 			 = attributes.vtextAnchor || null;
-		g.stroke 				 = attributes.stroke || null;
-		g.strokeWidth			 = attributes.strokeWidth || null;
-		g.fill 					 = attributes.fill || null;
-		g.backgroundImage 		 = attributes.backgroundImage || null;
-		g.backgroundFit 		 = attributes.backgroundFit || null;
-		g.backgroundPosX 		 = attributes.backgroundPosX || null;
-		g.backgroundPosY 		 = attributes.backgroundPosY || null;
-		g.backgroundWidth 		 = attributes.backgroundWidth || null;
-		g.backgroundHeight 		 = attributes.backgroundHeight || null;
-		g.backgroundImageOpacity = attributes.backgroundImageOpacity || null;
-		g.backgroundOpacity = attributes.backgroundOpacity || null;
+		g.id = utils.getChildByNameIgnoringNamespace(attributes, "id");
+		g.fontSize = utils.getChildByNameIgnoringNamespace(attributes, "fontSize");
+		g.fontFamily = utils.getChildByNameIgnoringNamespace(attributes, "fontFamily");
+		g.fontWeight = utils.getChildByNameIgnoringNamespace(attributes, "fontWeight");
+		g.fontStyle = utils.getChildByNameIgnoringNamespace(attributes, "fontStyle");
+		g.fontColor = utils.getChildByNameIgnoringNamespace(attributes, "fontColor");
+		g.textAnchor = utils.getChildByNameIgnoringNamespace(attributes, "textAnchor");
+		g.vtextAnchor = utils.getChildByNameIgnoringNamespace(attributes, "vtextAnchor");
+		g.stroke = utils.getChildByNameIgnoringNamespace(attributes, "stroke");
+		g.strokeWidth = utils.getChildByNameIgnoringNamespace(attributes, "strokeWidth");
+		g.fill = utils.getChildByNameIgnoringNamespace(attributes, "fill");
+		g.backgroundImage = utils.getChildByNameIgnoringNamespace(attributes, "backgroundImage");
+		g.backgroundFit = utils.getChildByNameIgnoringNamespace(attributes, "backgroundFit");
+		g.backgroundPosX = utils.getChildByNameIgnoringNamespace(attributes, "backgroundPosX");
+		g.backgroundPosY = utils.getChildByNameIgnoringNamespace(attributes, "backgroundPosY");
+		g.backgroundWidth = utils.getChildByNameIgnoringNamespace(attributes, "backgroundWidth");
+		g.backgroundHeight = utils.getChildByNameIgnoringNamespace(attributes, "backgroundHeight");
+		g.backgroundImageOpacity = utils.getChildByNameIgnoringNamespace(attributes, "backgroundImageOpacity");
+		g.backgroundOpacity = utils.getChildByNameIgnoringNamespace(attributes, "backgroundOpacity");
 	}
 	return g;
 };
@@ -491,26 +494,28 @@ Style.fromXML = function (string) {
  * @return {Style}
  */
 Style.fromObj = function (jsObj) {
-	if (typeof jsObj.style == 'undefined') {
+	var styleNode = utils.getChildByNameIgnoringNamespace(jsObj, "style");
+	if (styleNode === null) {
 		throw new Error("Bad XML provided, expected tagName style, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var style = new ns.Style();
-	jsObj = jsObj.style;
-	if(typeof jsObj != 'object') { // nothing inside, empty xml
+	jsObj = styleNode;
+	if (typeof jsObj != 'object') { // nothing inside, empty xml
 		return style;
 	}
 
-	if(jsObj.$) { // we have some attributes
+	if (jsObj.$) { // we have some attributes
 		var attributes = jsObj.$;
-		style.id = attributes.id || null;
-		style.name = attributes.name || null;
-		style.idList = attributes.idList || null;
+		style.id = utils.getChildByNameIgnoringNamespace(attributes, "id");
+		style.name = utils.getChildByNameIgnoringNamespace(attributes, "name");
+		style.idList = utils.getChildByNameIgnoringNamespace(attributes, "idList");
 	}
 
 	// children
-	if(jsObj.g) {
-		var g = ns.RenderGroup.fromObj({g: jsObj.g[0]});
+	var gNode = utils.getChildByNameIgnoringNamespace(jsObj, "g");
+	if (gNode) {
+		var g = ns.RenderGroup.fromObj({g: gNode[0]});
 		style.setRenderGroup(g);
 	}
 
@@ -595,20 +600,21 @@ ListOfStyles.fromXML = function (string) {
  * @return {ListOfStyles}
  */
 ListOfStyles.fromObj = function (jsObj) {
-	if (typeof jsObj.listOfStyles == 'undefined') {
+	var listOfStylesNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfStyles");
+	if (listOfStylesNode === null) {
 		throw new Error("Bad XML provided, expected tagName listOfStyles, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var listOfStyles = new ns.ListOfStyles();
-	jsObj = jsObj.listOfStyles;
-	if(typeof jsObj != 'object') { // nothing inside, empty xml
+	jsObj = listOfStylesNode;
+	if (typeof jsObj != 'object') { // nothing inside, empty xml
 		return listOfStyles;
 	}
 
 	// children
-	if(jsObj.style) {
-		var styles = jsObj.style;
-		for (var i=0; i < styles.length; i++) {
+	var styles = utils.getChildByNameIgnoringNamespace(jsObj, "style");
+	if (styles) {
+		for (var i = 0; i < styles.length; i++) {
 			var style = ns.Style.fromObj({style: styles[i]});
 			listOfStyles.addStyle(style);
 		}
@@ -773,12 +779,14 @@ ListOfBackgroundImages.fromXML = function (string) {
  * @return {ListOfBackgroundImages}
  */
 ListOfBackgroundImages.fromObj = function (jsObj) {
-	if (typeof jsObj.listOfBackgroundImages == 'undefined') {
+	var listOfBackgroundImagesNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfBackgroundImages");
+
+	if (listOfBackgroundImagesNode === null) {
 		throw new Error("Bad XML provided, expected tagName listOfBackgroundImages, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var listOfBackgroundImages = new ns.ListOfBackgroundImages();
-	jsObj = jsObj.listOfBackgroundImages;
+	jsObj = listOfBackgroundImagesNode;
 	if(typeof jsObj != 'object') { // nothing inside, empty xml
 		return listOfBackgroundImages;
 	}
@@ -812,7 +820,7 @@ ns.ListOfBackgroundImages = ListOfBackgroundImages;
  * @param {ListOfBackgroundImages=} params.listOfBackgroundImages
  */
 var RenderInformation = function (params) {
-	var params = checkParams(params, ['id', 'name', 'programName', 
+	var params = checkParams(params, ['id', 'name', 'programName',
 		'programVersion', 'backgroundColor', 'listOfColorDefinitions', 'listOfStyles', 'listOfBackgroundImages']);
 	this.id 					= params.id; // required, rest is optional
 	this.name 					= params.name;
@@ -909,36 +917,42 @@ RenderInformation.fromXML = function (string) {
  * @return {RenderInformation}
  */
 RenderInformation.fromObj = function (jsObj) {
-	if (typeof jsObj.renderInformation == 'undefined') {
+	var renderInformationNode = utils.getChildByNameIgnoringNamespace(jsObj, "renderInformation");
+	if (renderInformationNode === null) {
 		throw new Error("Bad XML provided, expected tagName renderInformation, got: " + Object.keys(jsObj)[0]);
 	}
 
 	var renderInformation = new ns.RenderInformation();
-	jsObj = jsObj.renderInformation;
+	jsObj =renderInformationNode;
 	if(typeof jsObj != 'object') { // nothing inside, empty xml
 		return renderInformation;
 	}
 
 	if(jsObj.$) { // we have some attributes
 		var attributes = jsObj.$;
-		renderInformation.id 				= attributes.id || null;
-		renderInformation.name 				= attributes.name || null;
-		renderInformation.programName 		= attributes.programName || null;
-		renderInformation.programVersion 	= attributes.programVersion || null;
-		renderInformation.backgroundColor 	= attributes.backgroundColor || null;
+		renderInformation.id 				= utils.getChildByNameIgnoringNamespace(attributes,"id");
+		renderInformation.name 				= utils.getChildByNameIgnoringNamespace(attributes,"name");
+		renderInformation.programName 		= utils.getChildByNameIgnoringNamespace(attributes,"programName");
+		renderInformation.programVersion 	= utils.getChildByNameIgnoringNamespace(attributes,"programVersion");
+		renderInformation.backgroundColor 	= utils.getChildByNameIgnoringNamespace(attributes,"backgroundColor");
 	}
 
 	// children
-	if(jsObj.listOfColorDefinitions) {
-		var listOfColorDefinitions = ns.ListOfColorDefinitions.fromObj({listOfColorDefinitions: jsObj.listOfColorDefinitions[0]});
+	var listOfColorDefinitionsNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfColorDefinitions");
+	if (listOfColorDefinitionsNode) {
+		var listOfColorDefinitions = ns.ListOfColorDefinitions.fromObj({listOfColorDefinitions: listOfColorDefinitionsNode});
 		renderInformation.setListOfColorDefinitions(listOfColorDefinitions);
 	}
-	if(jsObj.listOfStyles) {
-		var listOfStyles = ns.ListOfStyles.fromObj({listOfStyles: jsObj.listOfStyles[0]});
+
+	var listOfStylesNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfStyles");
+	if(listOfStylesNode) {
+		var listOfStyles = ns.ListOfStyles.fromObj({listOfStyles: listOfStylesNode});
 		renderInformation.setListOfStyles(listOfStyles);
 	}
-	if(jsObj.listOfBackgroundImages) {
-		var listOfBackgroundImages = ns.ListOfBackgroundImages.fromObj({listOfBackgroundImages: jsObj.listOfBackgroundImages[0]});
+
+	var listOfBackgroundImagesNode = utils.getChildByNameIgnoringNamespace(jsObj, "listOfBackgroundImages");
+	if (listOfBackgroundImagesNode) {
+		var listOfBackgroundImages = ns.ListOfBackgroundImages.fromObj({listOfBackgroundImages: listOfBackgroundImagesNode[0]});
 		renderInformation.setListOfBackgroundImages(listOfBackgroundImages);
 	}
 	return renderInformation;

--- a/src/libsbgn.js
+++ b/src/libsbgn.js
@@ -526,7 +526,7 @@ Extension.fromObj = function (jsObj) {
 		var extJsObj = jsObj[extName];
 
 		//extension.add(extInstance);
-		if (extName == 'renderInformation') {
+		if (extName === 'renderInformation' || extName.endsWith(':renderInformation')) {
 			var renderInformation = renderExt.RenderInformation.fromObj({renderInformation: extJsObj[0]});
 			extension.add(renderInformation);
 		}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -99,4 +99,34 @@ ns.buildString = function (obj) {
 	return xmlString_correctLabel;
 };
 
+/**
+ *  Returns child object from a map that correspond to the name. If attributes/node names are prefixed with namespace
+ *  this namespace is ignored. If such child does not exist null is returned.
+ *
+ * @param {Object} obj
+ * @param {string} childName
+ * @return {Object|null}
+ */
+ns.getChildByNameIgnoringNamespace = function (obj, childName) {
+  if (Array.isArray(obj)) {
+    for (var i = 0; i < obj.length; i++) {
+      var result = this.getChildByNameIgnoringNamespace(obj[i], childName);
+      if (result !== null) {
+        return result;
+      }
+    }
+  } else {
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        if (key === childName) {
+          return obj[key];
+        } else if (key.endsWith(":" + childName)) {
+          return obj[key];
+        }
+      }
+    }
+  }
+  return null;
+};
+
 module.exports = ns;

--- a/test/libsbgn-render.js
+++ b/test/libsbgn-render.js
@@ -359,4 +359,62 @@ describe('libsbgn-render', function() {
 			styles[0].renderGroup.fontSize.should.equal(14);
 		});
 	});
+  describe('different namespace', function () {
+    it('should parse attributes', function () {
+      var renderInfo = renderExt.RenderInformation.fromXML("<ns2:renderInformation " +
+        "ns2:id='a' ns2:name='name' ns2:programName='prog' " +
+        "ns2:programVersion='2.0.1a' ns2:backgroundColor='#FFFFFF'>" +
+        "</ns2:renderInformation>");
+      should.exist(renderInfo.id);
+      renderInfo.id.should.equal('a');
+      should.exist(renderInfo.name);
+      renderInfo.name.should.equal('name');
+      should.exist(renderInfo.programName);
+      renderInfo.programName.should.equal('prog');
+      should.exist(renderInfo.programVersion);
+      renderInfo.programVersion.should.equal('2.0.1a');
+      should.exist(renderInfo.backgroundColor);
+      renderInfo.backgroundColor.should.equal('#FFFFFF');
+    });
+    it('should parse listOfColorDefinitions', function () {
+      var xml =
+        "<ns2:renderInformation>" +
+        "<ns2:listOfColorDefinitions>" +
+        "<ns2:colorDefinition ns2:id='color_1' ns2:value='#ffffff7f' />" +
+        "<ns2:colorDefinition ns2:id='color_2' ns2:value='#555555' />" +
+        "</ns2:listOfColorDefinitions>" +
+        "</ns2:renderInformation>";
+      var renderInfo = renderExt.RenderInformation.fromXML(xml);
+
+      renderInfo.should.be.instanceOf(renderExt.RenderInformation);
+      renderInfo.listOfColorDefinitions.should.be.instanceOf(renderExt.ListOfColorDefinitions);
+
+      var listOfColors = renderInfo.listOfColorDefinitions;
+      listOfColors.colorDefinitions.should.have.lengthOf(2);
+      var c1 = listOfColors.colorDefinitions[0];
+      c1.should.be.instanceOf(renderExt.ColorDefinition);
+      c1.id.should.equal('color_1');
+      c1.value.should.equal('#ffffff7f');
+
+    });
+    it('should parse listOfStyles', function () {
+      var xml = "<ns2:renderInformation>" +
+        "<ns2:listOfStyles>" +
+        "<ns2:style ns2:id='xxx' ns2:idList='_82f19e9e-6aa2-42b3-8b5e-8cee17197085'>" +
+        "<ns2:g ns2:fontSize='14' ns2:fontFamily='Helvetica' ns2:fontWeight='normal' ns2:fontStyle='normal' ns2:strokeWidth='3.25' />" +
+        "</ns2:style>" +
+        "</ns2:listOfStyles>" +
+        "</ns2:renderInformation>";
+
+      var renderInfo = renderExt.RenderInformation.fromXML(xml);
+
+      var styles = renderInfo.listOfStyles.styles;
+      styles.should.have.lengthOf(1);
+      styles[0].should.be.instanceOf(renderExt.Style);
+      styles[0].id.should.equal('xxx');
+      styles[0].renderGroup.should.be.instanceOf(renderExt.RenderGroup);
+      styles[0].renderGroup.fontSize.should.equal(14);
+    });
+
+  });
 });


### PR DESCRIPTION
This PR should resolve https://github.com/sbgn/libsbgn.js/issues/5. I have tried to follow the project convention code. In principle the changes will allow to ignore namespace prefixes when parsing render extension data. I added unit tests that should cover all changes I made.

There is one thing that I was not sure about: what are the target browsers? There are two methods that I used and are in the JavaScript for quite some time, but if the target browser is old Internet Explorer it won't work: 
* `Array.isArray` - https://github.com/sbgn/libsbgn.js/compare/master...piotr-gawron:namespace-issue-with-render-exception?expand=1#diff-b5c8f479fd199c465e4e5fce91bed60dR111
* `string.endWith` - https://github.com/sbgn/libsbgn.js/compare/master...piotr-gawron:namespace-issue-with-render-exception?expand=1#diff-b5c8f479fd199c465e4e5fce91bed60dR123
