### PR TITLE
Fixed Typo on "Sate" instead of "State"

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -62,7 +62,7 @@ ns.removePrefixForSbgnTags = function (name){
 		"port",
 		"sbgn",
 		"start",
-		"sate"
+		"state"
 	]);
 
 	if(name.indexOf(":") !== -1) { // some prefix found


### PR DESCRIPTION
Opened because of [issue 706](https://github.com/iVis-at-Bilkent/newt/issues/706) on Newt. This is a complete fix for that issue.